### PR TITLE
Set packageManager field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,5 +14,6 @@
     "@types/node": "20.14.11",
     "@types/react": "18.3.3",
     "@types/react-dom": "18.3.0"
-  }
+  },
+  "packageManager": "npm@10.0.0"
 }


### PR DESCRIPTION
## Set packageManager field in package.json

## Problem

The `package.json` file is missing or has `null` for the `packageManager` field, which causes build failures on Vercel and other platforms when they cannot determine which package manager to use.

**Detected package manager:** npm@10.0.0

## Changes

- Set `packageManager` field to `"npm@10.0.0"` in package.json

## Context

This fix ensures build systems can correctly identify and use the proper package manager based on the lock file present in the repository.

Related to CVE-2025-55182 automated patching (FORGE-2622).
See: https://linear.app/mavenagi/issue/FORGE-2622

<!-- Patch Identifiers: patch:package-manager-field -->

🤖 Generated with [security-audit](https://github.com/mavenagi/security-audit)