### PR TITLE
fix(elevio): use API tags and slug for article URL construction

### DIFF
--- a/scripts/validate-live.ts
+++ b/scripts/validate-live.ts
@@ -30,7 +30,7 @@ const settings = {
   token,
   helpCenterUrl:
     process.env.ELEVIO_HELP_CENTER_URL ??
-    "https://www.tripadvisorsupport.com/en-US/hc/traveler",
+    "https://www.tripadvisorsupport.com/en-US/hc",
 };
 
 const headers = {
@@ -41,14 +41,23 @@ const headers = {
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
+/** Extract section from ct_ prefixed tags (e.g. ct_traveler → traveler) */
+function extractSection(tags: string[]): string | undefined {
+  const tag = tags.find((t) => t.startsWith("ct_"));
+  return tag?.slice(3);
+}
+
 function buildArticleUrl(
   helpCenterUrl: string | undefined,
   articleId: number,
-  _title: string,
+  slug: string,
+  tags: string[],
 ): string {
   if (!helpCenterUrl) return "";
+  const section = extractSection(tags);
+  if (!section) return "";
   const baseUrl = helpCenterUrl.replace(/\/$/, "");
-  return `${baseUrl}/articles/${articleId}`;
+  return `${baseUrl}/${section}/articles/${articleId}-${slug}`;
 }
 
 const ENGLISH_LANGUAGE_IDS = ["en", "en-us"];
@@ -116,6 +125,7 @@ interface ArticleDetail {
   article: {
     id: number;
     title: string;
+    slug: string;
     translations: {
       id: number;
       title: string;
@@ -190,17 +200,24 @@ async function testConversion(htmlBody: string) {
 
 // ── Step 5: URL Construction ─────────────────────────────────────────
 
-function testUrlConstruction(articleId: number, title: string) {
+function testUrlConstruction(
+  articleId: number,
+  slug: string,
+  tags: string[],
+) {
   console.log("\n─── Step 5: URL Construction (SOLN-63) ───");
-  const url = buildArticleUrl(settings.helpCenterUrl, articleId, title);
+  info("Slug", slug);
+  info("Tags", tags.join(", ") || "(none)");
+
+  const url = buildArticleUrl(settings.helpCenterUrl, articleId, slug, tags);
   if (url) {
     passed("buildArticleUrl", url);
   } else {
-    failed("buildArticleUrl", "returned empty string");
+    failed("buildArticleUrl", "returned empty string (no ct_ tag?)");
   }
 
   // Also test without helpCenterUrl
-  const noUrl = buildArticleUrl(undefined, articleId, title);
+  const noUrl = buildArticleUrl(undefined, articleId, slug, tags);
   if (noUrl === "") {
     passed("No helpCenterUrl", "correctly returns empty string");
   } else {
@@ -257,14 +274,22 @@ async function main() {
       const alt = await fetchAndValidateArticle(list.articles[i].id);
       if (alt) {
         const md = await testConversion(alt.english.body);
-        const url = testUrlConstruction(alt.article.id, alt.english.title);
+        const url = testUrlConstruction(
+          alt.article.id,
+          alt.article.slug,
+          alt.article.tags,
+        );
         showDocumentShape(alt.article.id, alt.english.title, md, url);
         break;
       }
     }
   } else {
     const md = await testConversion(detail.english.body);
-    const url = testUrlConstruction(detail.article.id, detail.english.title);
+    const url = testUrlConstruction(
+      detail.article.id,
+      detail.article.slug,
+      detail.article.tags,
+    );
     showDocumentShape(detail.article.id, detail.english.title, md, url);
   }
 
@@ -273,7 +298,7 @@ async function main() {
     `  Total articles: ${list.total_entries} across ${list.total_pages} pages`,
   );
   console.log(
-    `  Help center URL pattern: ${settings.helpCenterUrl}/en/articles/{id}-{slug}`,
+    `  Help center URL pattern: ${settings.helpCenterUrl}/{section}/articles/{id}-{slug}`,
   );
   console.log("  Done.\n");
 }

--- a/src/knowledge-hooks.test.ts
+++ b/src/knowledge-hooks.test.ts
@@ -102,6 +102,7 @@ describe("Elevio Knowledge Base Integration", () => {
         article: {
           id: 101,
           title: "Getting Started",
+          slug: "getting-started",
           translations: [
             {
               id: 1,
@@ -113,7 +114,7 @@ describe("Elevio Knowledge Base Integration", () => {
             },
           ],
           keywords: [],
-          tags: [],
+          tags: ["ct_traveler"],
           created_at: "2024-01-01T00:00:00Z",
           updated_at: "2024-01-01T00:00:00Z",
         },
@@ -124,6 +125,7 @@ describe("Elevio Knowledge Base Integration", () => {
         article: {
           id: 102,
           title: "FAQ",
+          slug: "faq",
           translations: [
             {
               id: 2,
@@ -135,7 +137,7 @@ describe("Elevio Knowledge Base Integration", () => {
             },
           ],
           keywords: [],
-          tags: [],
+          tags: ["ct_owner"],
           created_at: "2024-01-01T00:00:00Z",
           updated_at: "2024-01-01T00:00:00Z",
         },
@@ -182,7 +184,7 @@ describe("Elevio Knowledge Base Integration", () => {
         expect.objectContaining({
           title: "Getting Started",
           contentType: "MARKDOWN",
-          url: "https://help.example.com/articles/101",
+          url: "https://help.example.com/traveler/articles/101-getting-started",
           knowledgeDocumentId: { referenceId: "101" },
         }),
       );
@@ -220,6 +222,7 @@ describe("Elevio Knowledge Base Integration", () => {
       fetchMock.get("https://api.elev.io/v1/articles/201", {
         article: {
           id: 201,
+          slug: "page-1-article",
           translations: [
             {
               id: 1,
@@ -231,7 +234,7 @@ describe("Elevio Knowledge Base Integration", () => {
             },
           ],
           keywords: [],
-          tags: [],
+          tags: ["ct_traveler"],
           created_at: "2024-01-01T00:00:00Z",
           updated_at: "2024-01-01T00:00:00Z",
         },
@@ -240,6 +243,7 @@ describe("Elevio Knowledge Base Integration", () => {
       fetchMock.get("https://api.elev.io/v1/articles/202", {
         article: {
           id: 202,
+          slug: "page-2-article",
           translations: [
             {
               id: 2,
@@ -251,7 +255,7 @@ describe("Elevio Knowledge Base Integration", () => {
             },
           ],
           keywords: [],
-          tags: [],
+          tags: ["ct_owner"],
           created_at: "2024-01-01T00:00:00Z",
           updated_at: "2024-01-01T00:00:00Z",
         },

--- a/src/knowledge-hooks.ts
+++ b/src/knowledge-hooks.ts
@@ -144,11 +144,12 @@ export async function convertToMavenDocuments(
       data: englishTranslation.body,
     });
 
-    // Build public article URL (SOLN-63 fix)
+    // Build public article URL using API-provided slug and tags (SOLN-63 fix)
     const url = buildArticleUrl(
       settings.helpCenterUrl,
       article.id,
-      englishTranslation.title,
+      article.slug,
+      article.tags,
     );
 
     documents.push({

--- a/src/lib/knowledge.ts
+++ b/src/lib/knowledge.ts
@@ -23,6 +23,7 @@ export interface ElevioArticleDetailResponse {
 export interface ElevioArticleDetail {
   id: number;
   title: string;
+  slug: string;
   status: string;
   category_id: number | null;
   translations: ElevioTranslation[];

--- a/src/lib/url.test.ts
+++ b/src/lib/url.test.ts
@@ -1,57 +1,83 @@
 import { describe, expect, it } from "vitest";
 
-import { buildArticleUrl, slugifyTitle } from "@/lib/url";
+import { buildArticleUrl, extractSection } from "@/lib/url";
 
-describe("slugifyTitle", () => {
-  it("should convert title to kebab-case", () => {
-    expect(slugifyTitle("Getting Started")).toBe("getting-started");
+describe("extractSection", () => {
+  it("should extract section from ct_ prefixed tag", () => {
+    expect(extractSection(["ct_traveler"])).toBe("traveler");
   });
 
-  it("should remove special characters", () => {
-    expect(slugifyTitle("FAQ: Billing & Payments")).toBe(
-      "faq-billing-payments",
+  it("should extract section from ct_owner tag", () => {
+    expect(extractSection(["ct_owner"])).toBe("owner");
+  });
+
+  it("should return first matching section tag", () => {
+    expect(extractSection(["other", "ct_traveler", "ct_owner"])).toBe(
+      "traveler",
     );
   });
 
-  it("should handle empty string", () => {
-    expect(slugifyTitle("")).toBe("");
+  it("should return undefined when no section tag exists", () => {
+    expect(extractSection(["some-tag", "another"])).toBeUndefined();
   });
 
-  it("should collapse multiple spaces and dashes", () => {
-    expect(slugifyTitle("How  to   Use  This")).toBe("how-to-use-this");
-  });
-
-  it("should trim leading and trailing dashes", () => {
-    expect(slugifyTitle(" Hello World ")).toBe("hello-world");
+  it("should return undefined for empty tags", () => {
+    expect(extractSection([])).toBeUndefined();
   });
 });
 
 describe("buildArticleUrl", () => {
-  it("should construct URL from helpCenterUrl and article ID", () => {
+  it("should construct full URL with section, id, and slug", () => {
     expect(
-      buildArticleUrl("https://help.example.com/en", 123, "Getting Started"),
-    ).toBe("https://help.example.com/en/articles/123");
+      buildArticleUrl(
+        "https://www.tripadvisorsupport.com/en-US/hc",
+        377,
+        "reporting-inaccurate-business-information",
+        ["ct_traveler"],
+      ),
+    ).toBe(
+      "https://www.tripadvisorsupport.com/en-US/hc/traveler/articles/377-reporting-inaccurate-business-information",
+    );
+  });
+
+  it("should use ct_owner tag for owner section", () => {
+    expect(
+      buildArticleUrl(
+        "https://www.tripadvisorsupport.com/en-US/hc",
+        402,
+        "updating-my-business-details",
+        ["ct_owner"],
+      ),
+    ).toBe(
+      "https://www.tripadvisorsupport.com/en-US/hc/owner/articles/402-updating-my-business-details",
+    );
   });
 
   it("should strip trailing slash from helpCenterUrl", () => {
-    expect(buildArticleUrl("https://help.example.com/", 456, "Test")).toBe(
-      "https://help.example.com/articles/456",
-    );
+    expect(
+      buildArticleUrl("https://help.example.com/", 456, "test-article", [
+        "ct_traveler",
+      ]),
+    ).toBe("https://help.example.com/traveler/articles/456-test-article");
   });
 
   it("should return empty string when helpCenterUrl is undefined", () => {
-    expect(buildArticleUrl(undefined, 123, "Test")).toBe("");
+    expect(
+      buildArticleUrl(undefined, 123, "test", ["ct_traveler"]),
+    ).toBe("");
   });
 
-  it("should work with nested help center base paths", () => {
+  it("should return empty string when no section tag exists", () => {
     expect(
-      buildArticleUrl(
-        "https://www.tripadvisorsupport.com/en-US/hc/traveler",
-        377,
-        "Reporting inaccurate business information",
-      ),
-    ).toBe(
-      "https://www.tripadvisorsupport.com/en-US/hc/traveler/articles/377",
-    );
+      buildArticleUrl("https://help.example.com", 123, "test", [
+        "some-other-tag",
+      ]),
+    ).toBe("");
+  });
+
+  it("should return empty string when tags are empty", () => {
+    expect(
+      buildArticleUrl("https://help.example.com", 123, "test", []),
+    ).toBe("");
   });
 });

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -1,34 +1,45 @@
-/** Slugify a title for URL construction */
-export function slugifyTitle(title: string): string {
-  return title
-    .toLowerCase()
-    .replace(/[^a-z0-9\s-]/g, "")
-    .replace(/\s+/g, "-")
-    .replace(/-+/g, "-")
-    .replace(/^-|-$/g, "");
+/** Prefix used on Elevio tags that map to help center URL sections */
+const TAG_SECTION_PREFIX = "ct_";
+
+/**
+ * Extract the help center section from an article's tags.
+ *
+ * Elevio tags like "ct_traveler" or "ct_owner" map to URL sections
+ * (e.g. /traveler, /owner). Returns the first matching section,
+ * or undefined if no section tag is present.
+ */
+export function extractSection(tags: string[]): string | undefined {
+  const sectionTag = tags.find((t) => t.startsWith(TAG_SECTION_PREFIX));
+  return sectionTag?.slice(TAG_SECTION_PREFIX.length);
 }
 
 /**
  * Construct the public URL for an Elevio help center article.
  *
+ * Uses the article's tags to determine the section and the API-provided slug.
+ *
+ * Pattern: {helpCenterUrl}/{section}/articles/{id}-{slug}
+ *
  * The `helpCenterUrl` setting should be the base path up to (but not including)
- * `/articles/`. For example:
- *   - "https://www.tripadvisorsupport.com/en-US/hc/traveler"
- *   - "https://help.example.com/en"
+ * the section. For example: "https://www.tripadvisorsupport.com/en-US/hc"
  *
- * Pattern: {helpCenterUrl}/articles/{id}
- *
- * Returns empty string if helpCenterUrl is not configured.
+ * Returns empty string if helpCenterUrl is not configured or no section tag exists.
  */
 export function buildArticleUrl(
   helpCenterUrl: string | undefined,
   articleId: number,
-  _title: string,
+  slug: string,
+  tags: string[],
 ): string {
   if (!helpCenterUrl) {
     return "";
   }
 
+  const section = extractSection(tags);
+  if (!section) {
+    return "";
+  }
+
   const baseUrl = helpCenterUrl.replace(/\/$/, "");
-  return `${baseUrl}/articles/${articleId}`;
+  return `${baseUrl}/${section}/articles/${articleId}-${slug}`;
 }


### PR DESCRIPTION
## Summary

- Elevio articles have `ct_` prefixed tags (`ct_traveler`, `ct_owner`) that map to help center URL sections. This change uses those tags along with the API-provided `slug` field to build correct article URLs.
- The `helpCenterUrl` setting can now be a simple base path (e.g. `https://www.tripadvisorsupport.com/en-US/hc`) rather than needing to include a specific section.
- URL pattern: `{helpCenterUrl}/{section}/articles/{id}-{slug}`

## Changes

- `src/lib/url.ts` — Added `extractSection(tags)` to parse `ct_` tags; rewrote `buildArticleUrl` to accept `slug` and `tags`
- `src/lib/knowledge.ts` — Added `slug` field to `ElevioArticleDetail` type
- `src/knowledge-hooks.ts` — Passes `article.slug` and `article.tags` to URL builder
- `src/lib/url.test.ts` — Tests for `extractSection` + updated `buildArticleUrl` tests
- `src/knowledge-hooks.test.ts` — Mock data updated with `slug`/`tags`, URL assertion updated
- `scripts/validate-live.ts` — Updated local helpers to match new pattern

## Test plan

- [x] All 28 unit tests pass (`pnpm test`)
- [x] Build succeeds (`pnpm build`)
- [x] Verified against live Elevio API: `ct_traveler` → `/traveler`, `ct_owner` → `/owner`
- [x] Verified constructed URLs return 200 against TripAdvisor help center

🤖 Generated with [Claude Code](https://claude.com/claude-code)