### PR TITLE
fix(elevio): chunk fetchData to avoid 524 timeouts

### DIFF
--- a/src/knowledge-hooks.test.ts
+++ b/src/knowledge-hooks.test.ts
@@ -300,3 +300,150 @@ describe("Elevio Knowledge Base Integration", () => {
     },
   );
 });
+
+describe("fetchData chunking", () => {
+  const mockSettings = {
+    key: "test-api-key",
+    token: "test-token",
+    helpCenterUrl: "https://help.example.com",
+  };
+
+  const mockEventData = {
+    organizationId: "org1",
+    agentId: "agent1",
+    settings: mockSettings,
+  };
+
+  beforeEach(() => {
+    fetchMock.removeRoutes();
+    fetchMock.clearHistory();
+    fetchMock.mockGlobal();
+  });
+
+  afterEach(() => {
+    fetchMock.removeRoutes();
+    fetchMock.clearHistory();
+    fetchMock.unmockGlobal();
+  });
+
+  it("should return empty result when done", async () => {
+    const { fetchData } = await import("@/knowledge-hooks");
+
+    const result = await fetchData(
+      { page: 1, totalPages: 1, pendingArticles: [], done: true },
+      mockEventData,
+      250,
+    );
+
+    expect(result.result).toHaveLength(0);
+  });
+
+  it("should chunk pending articles by ELEVIO_CHUNK_SIZE", async () => {
+    const { fetchData } = await import("@/knowledge-hooks");
+
+    // Create 15 pending article summaries (ELEVIO_CHUNK_SIZE is 10)
+    const pending = Array.from({ length: 15 }, (_, i) => ({
+      id: 300 + i,
+      title: `Article ${i}`,
+      status: "published",
+      category_id: null,
+      created_at: "2024-01-01T00:00:00Z",
+      updated_at: "2024-01-01T00:00:00Z",
+    }));
+
+    // Mock detail endpoints for all 15 articles
+    for (const article of pending) {
+      fetchMock.get(`https://api.elev.io/v1/articles/${article.id}`, {
+        article: {
+          id: article.id,
+          title: article.title,
+          slug: `article-${article.id}`,
+          translations: [
+            {
+              id: article.id,
+              title: article.title,
+              body: "<p>Content</p>",
+              language_id: "en",
+              created_at: "2024-01-01T00:00:00Z",
+              updated_at: "2024-01-01T00:00:00Z",
+            },
+          ],
+          keywords: [],
+          tags: ["ct_traveler"],
+          created_at: "2024-01-01T00:00:00Z",
+          updated_at: "2024-01-01T00:00:00Z",
+        },
+      });
+    }
+
+    // First chunk: should return 10 articles, leave 5 pending
+    const chunk1 = await fetchData(
+      { page: 1, totalPages: 1, pendingArticles: pending, done: false },
+      mockEventData,
+      250,
+    );
+
+    expect(chunk1.result).toHaveLength(10);
+    expect(chunk1.updatedMetadata?.pendingArticles).toHaveLength(5);
+    expect(chunk1.updatedMetadata?.done).toBe(false);
+
+    // Second chunk: should return remaining 5 articles
+    const chunk2 = await fetchData(
+      chunk1.updatedMetadata!,
+      mockEventData,
+      250,
+    );
+
+    expect(chunk2.result).toHaveLength(5);
+    expect(chunk2.updatedMetadata?.pendingArticles).toHaveLength(0);
+    // Last page and all drained → done
+    expect(chunk2.updatedMetadata?.done).toBe(true);
+  });
+
+  it("should fetch next page when pending articles are drained", async () => {
+    const { fetchData } = await import("@/knowledge-hooks");
+
+    // Page 2 articles mock
+    fetchMock.get("https://api.elev.io/v1/articles?status=published&page=2", {
+      articles: [
+        { id: 401, title: "Page 2 Art", status: "published" },
+      ],
+      page_number: 2,
+      total_pages: 2,
+      total_entries: 2,
+    });
+
+    fetchMock.get("https://api.elev.io/v1/articles/401", {
+      article: {
+        id: 401,
+        title: "Page 2 Art",
+        slug: "page-2-art",
+        translations: [
+          {
+            id: 401,
+            title: "Page 2 Art",
+            body: "<p>Content</p>",
+            language_id: "en",
+            created_at: "2024-01-01T00:00:00Z",
+            updated_at: "2024-01-01T00:00:00Z",
+          },
+        ],
+        keywords: [],
+        tags: ["ct_owner"],
+        created_at: "2024-01-01T00:00:00Z",
+        updated_at: "2024-01-01T00:00:00Z",
+      },
+    });
+
+    // Metadata: page 1 drained, more pages exist
+    const result = await fetchData(
+      { page: 1, totalPages: 2, pendingArticles: [], done: false },
+      mockEventData,
+      250,
+    );
+
+    expect(result.result).toHaveLength(1);
+    expect(result.updatedMetadata?.page).toBe(2);
+    expect(result.updatedMetadata?.done).toBe(true);
+  });
+});

--- a/src/knowledge-hooks.ts
+++ b/src/knowledge-hooks.ts
@@ -5,11 +5,15 @@ import { MavenAGI } from "mavenagi";
 
 import { fetchArticleById, fetchArticlesPage } from "@/lib/api";
 import {
+  ELEVIO_CHUNK_SIZE,
   ENGLISH_LANGUAGE_IDS,
   KNOWLEDGE_BASE_ID,
   KNOWLEDGE_BASE_NAME,
 } from "@/lib/constants";
-import type { ElevioArticleDetail } from "@/lib/knowledge";
+import type {
+  ElevioArticleDetail,
+  ElevioArticleSummary,
+} from "@/lib/knowledge";
 import { buildArticleUrl } from "@/lib/url";
 
 // ── Hook execution order ──────────────────────────────────────────────
@@ -17,8 +21,11 @@ import { buildArticleUrl } from "@/lib/url";
 //   → [fetchData → convertToMavenDocuments → getMavenKBId]* (loops until fetchData returns empty)
 
 interface ElevioMetadata {
+  /** Current page in the Elevio articles list API */
   page: number;
   totalPages: number;
+  /** Article summaries from the current page waiting to be fetched in detail */
+  pendingArticles: ElevioArticleSummary[];
   done: boolean;
 }
 
@@ -43,7 +50,8 @@ export async function validateInputs(eventData: any): Promise<void> {
 
 /**
  * Step 2 — Fetch first page to initialize pagination metadata.
- * The returned object is cached in Redis and passed to subsequent hooks.
+ * Stores the first page's article summaries in pendingArticles so
+ * fetchData can drain them in small chunks without re-fetching.
  */
 export async function fetchMetadataAndSetup(
   eventData: any,
@@ -54,6 +62,7 @@ export async function fetchMetadataAndSetup(
   return {
     page: 1,
     totalPages: firstPage.total_pages,
+    pendingArticles: firstPage.articles,
     done: firstPage.total_pages === 0,
   } satisfies ElevioMetadata;
 }
@@ -75,8 +84,15 @@ export function createMavenKBIds(
 }
 
 /**
- * Step 4 (Extract) — Fetch one page of articles with full detail.
- * Called in a loop by the framework. Returns empty result to stop.
+ * Step 4 (Extract) — Fetch a small chunk of articles with full detail.
+ *
+ * Called in a loop by the framework. Each invocation takes at most
+ * ELEVIO_CHUNK_SIZE articles from `pendingArticles`, fetches their
+ * detail (concurrently via the rate limiter), and returns them.
+ * When pendingArticles is drained, fetches the next page. Returns
+ * empty result to signal completion.
+ *
+ * This keeps each Inngest step small enough to avoid 524 timeouts.
  */
 export async function fetchData(
   metadata: Record<string, any>,
@@ -93,23 +109,59 @@ export async function fetchData(
   }
 
   const { settings } = eventData;
-  const articlesResponse = await fetchArticlesPage(settings, meta.page);
+  let { pendingArticles, page, totalPages } = meta;
 
-  // Fetch full detail for each article to get translations with body content
-  const fullArticles: ElevioArticleDetail[] = [];
-  for (const article of articlesResponse.articles) {
-    const detail = await fetchArticleById(settings, article.id);
-    fullArticles.push(detail.article);
+  // If no pending articles, fetch the next page
+  if (pendingArticles.length === 0) {
+    const nextPage = page + 1;
+    if (nextPage > totalPages) {
+      return {
+        result: [],
+        updatedMetadata: { ...meta, done: true } satisfies ElevioMetadata,
+      };
+    }
+
+    const articlesResponse = await fetchArticlesPage(settings, nextPage);
+    pendingArticles = articlesResponse.articles;
+    page = nextPage;
+    totalPages = articlesResponse.total_pages;
+
+    // Edge case: page returned no articles
+    if (pendingArticles.length === 0) {
+      return {
+        result: [],
+        updatedMetadata: {
+          page,
+          totalPages,
+          pendingArticles: [],
+          done: true,
+        } satisfies ElevioMetadata,
+      };
+    }
   }
 
-  const hasMore = meta.page < articlesResponse.total_pages;
+  // Take a small chunk from the pending queue
+  const batch = pendingArticles.slice(0, ELEVIO_CHUNK_SIZE);
+  const remaining = pendingArticles.slice(ELEVIO_CHUNK_SIZE);
+
+  // Fetch full detail concurrently (bounded by Bottleneck rate limiter)
+  const fullArticles = await Promise.all(
+    batch.map(async (article) => {
+      const detail = await fetchArticleById(settings, article.id);
+      return detail.article;
+    }),
+  );
+
+  const allDrained = remaining.length === 0;
+  const noMorePages = page >= totalPages;
 
   return {
     result: fullArticles as unknown as Record<string, any>[],
     updatedMetadata: {
-      page: hasMore ? meta.page + 1 : meta.page,
-      totalPages: articlesResponse.total_pages,
-      done: !hasMore,
+      page,
+      totalPages,
+      pendingArticles: remaining,
+      done: allDrained && noMorePages,
     } satisfies ElevioMetadata,
   };
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -10,3 +10,6 @@ export const ENGLISH_LANGUAGE_IDS = ["en", "en-us"] as const;
 // Rate limiting: conservative defaults for Elevio API
 export const API_MAX_CONCURRENT = 5;
 export const API_MIN_TIME_MS = 200;
+
+// Max articles to fetch per chunk (keeps each Inngest step under timeout)
+export const ELEVIO_CHUNK_SIZE = 10;


### PR DESCRIPTION
## Summary

- `fetchData` now processes articles in small batches (`ELEVIO_CHUNK_SIZE = 10`) instead of fetching an entire page at once
- Article summaries are stored in a `pendingArticles` queue in metadata, drained across multiple Inngest steps
- Detail fetches run concurrently (bounded by Bottleneck rate limiter) instead of sequentially
- Next API page is fetched only when the pending queue is empty
- Follows the same chunking pattern as the Confluence connector

## Root Cause

The apps-core `processFunction` runs `fetchData` + `convertToMavenDocuments` + Maven API uploads inside a **single `step.run()`**. Previously `fetchData` fetched all articles on a page sequentially (N detail requests at 200ms rate limit each), then the step also had to convert HTML to Markdown and upload to Maven. For pages with many articles, this single step exceeded Cloudflare's timeout, causing 524 errors.

## Changes

- `src/knowledge-hooks.ts` — Rewrote `fetchData` with `pendingArticles` queue and `ELEVIO_CHUNK_SIZE` batching; updated `fetchMetadataAndSetup` to seed the queue with page 1 articles
- `src/lib/constants.ts` — Added `ELEVIO_CHUNK_SIZE = 10`
- `src/knowledge-hooks.test.ts` — Added 3 unit tests for chunking: done state, batch splitting (15 articles → 10+5), and next-page fetching when queue drains

## Test plan

- [x] All 34 tests pass (`pnpm test`)
- [x] Build succeeds (`pnpm build`)
- [x] Chunking test verifies 15 pending articles split into chunks of 10 + 5
- [x] Chunking test verifies automatic page advancement when queue empties
- [ ] Deploy and verify no more 524 errors on TripAdvisor knowledge sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)