### PR TITLE
fix(elevio): parallelize conversion and reduce chunk size to fix 524s

### DIFF
--- a/src/knowledge-hooks.test.ts
+++ b/src/knowledge-hooks.test.ts
@@ -341,8 +341,8 @@ describe("fetchData chunking", () => {
   it("should chunk pending articles by ELEVIO_CHUNK_SIZE", async () => {
     const { fetchData } = await import("@/knowledge-hooks");
 
-    // Create 15 pending article summaries (ELEVIO_CHUNK_SIZE is 10)
-    const pending = Array.from({ length: 15 }, (_, i) => ({
+    // Create 12 pending article summaries (ELEVIO_CHUNK_SIZE is 5)
+    const pending = Array.from({ length: 12 }, (_, i) => ({
       id: 300 + i,
       title: `Article ${i}`,
       status: "published",
@@ -351,7 +351,7 @@ describe("fetchData chunking", () => {
       updated_at: "2024-01-01T00:00:00Z",
     }));
 
-    // Mock detail endpoints for all 15 articles
+    // Mock detail endpoints for all 12 articles
     for (const article of pending) {
       fetchMock.get(`https://api.elev.io/v1/articles/${article.id}`, {
         article: {
@@ -376,18 +376,18 @@ describe("fetchData chunking", () => {
       });
     }
 
-    // First chunk: should return 10 articles, leave 5 pending
+    // First chunk: should return 5 articles, leave 7 pending
     const chunk1 = await fetchData(
       { page: 1, totalPages: 1, pendingArticles: pending, done: false },
       mockEventData,
       250,
     );
 
-    expect(chunk1.result).toHaveLength(10);
-    expect(chunk1.updatedMetadata?.pendingArticles).toHaveLength(5);
+    expect(chunk1.result).toHaveLength(5);
+    expect(chunk1.updatedMetadata?.pendingArticles).toHaveLength(7);
     expect(chunk1.updatedMetadata?.done).toBe(false);
 
-    // Second chunk: should return remaining 5 articles
+    // Second chunk: should return 5 articles, leave 2 pending
     const chunk2 = await fetchData(
       chunk1.updatedMetadata!,
       mockEventData,
@@ -395,9 +395,20 @@ describe("fetchData chunking", () => {
     );
 
     expect(chunk2.result).toHaveLength(5);
-    expect(chunk2.updatedMetadata?.pendingArticles).toHaveLength(0);
+    expect(chunk2.updatedMetadata?.pendingArticles).toHaveLength(2);
+    expect(chunk2.updatedMetadata?.done).toBe(false);
+
+    // Third chunk: should return remaining 2 articles
+    const chunk3 = await fetchData(
+      chunk2.updatedMetadata!,
+      mockEventData,
+      250,
+    );
+
+    expect(chunk3.result).toHaveLength(2);
+    expect(chunk3.updatedMetadata?.pendingArticles).toHaveLength(0);
     // Last page and all drained → done
-    expect(chunk2.updatedMetadata?.done).toBe(true);
+    expect(chunk3.updatedMetadata?.done).toBe(true);
   });
 
   it("should fetch next page when pending articles are drained", async () => {

--- a/src/knowledge-hooks.ts
+++ b/src/knowledge-hooks.ts
@@ -177,41 +177,46 @@ export async function convertToMavenDocuments(
 ): Promise<ConvertChunkResult> {
   const articles = fetchResult as unknown as ElevioArticleDetail[];
   const { settings } = eventData;
-  const documents: MavenAGI.KnowledgeDocumentRequest[] = [];
 
-  for (const article of articles) {
-    const englishTranslation = article.translations.find((t) =>
-      ENGLISH_LANGUAGE_IDS.includes(
-        t.language_id as (typeof ENGLISH_LANGUAGE_IDS)[number],
-      ),
+  // Filter to English translations first, then convert HTML→Markdown concurrently.
+  // Sequential conversion was a 524-timeout bottleneck — large HTML bodies
+  // can take several seconds each through the knowledge-converter.
+  const articlesWithEnglish = articles
+    .map((article) => {
+      const englishTranslation = article.translations.find((t) =>
+        ENGLISH_LANGUAGE_IDS.includes(
+          t.language_id as (typeof ENGLISH_LANGUAGE_IDS)[number],
+        ),
+      );
+      return englishTranslation ? { article, englishTranslation } : null;
+    })
+    .filter(
+      (item): item is NonNullable<typeof item> => item !== null,
     );
 
-    // Skip articles without English translation
-    if (!englishTranslation) {
-      continue;
-    }
+  // Convert HTML→Markdown concurrently for all English articles
+  const documents: MavenAGI.KnowledgeDocumentRequest[] = await Promise.all(
+    articlesWithEnglish.map(async ({ article, englishTranslation }) => {
+      const [_extractedTitle, markdownContent] = await convert({
+        data: englishTranslation.body,
+      });
 
-    // Convert HTML body to Markdown
-    const [_extractedTitle, markdownContent] = await convert({
-      data: englishTranslation.body,
-    });
+      const url = buildArticleUrl(
+        settings.helpCenterUrl,
+        article.id,
+        article.slug,
+        article.tags,
+      );
 
-    // Build public article URL using API-provided slug and tags (SOLN-63 fix)
-    const url = buildArticleUrl(
-      settings.helpCenterUrl,
-      article.id,
-      article.slug,
-      article.tags,
-    );
-
-    documents.push({
-      knowledgeDocumentId: { referenceId: `${article.id}` },
-      title: englishTranslation.title,
-      content: markdownContent ?? "",
-      contentType: "MARKDOWN",
-      url,
-    });
-  }
+      return {
+        knowledgeDocumentId: { referenceId: `${article.id}` },
+        title: englishTranslation.title,
+        content: markdownContent ?? "",
+        contentType: "MARKDOWN",
+        url,
+      };
+    }),
+  );
 
   return {
     documents,

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -1,4 +1,5 @@
 import { apiLimiter, buildBaseUrl, buildHeaders } from "@/lib/client";
+import { FETCH_TIMEOUT_MS } from "@/lib/constants";
 import type {
   ElevioArticleDetailResponse,
   ElevioArticlesListResponse,
@@ -13,6 +14,7 @@ async function callElevioApi<T>(
     fetch(endpoint, {
       method: "GET",
       headers: buildHeaders(settings),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     }),
   );
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -11,5 +11,11 @@ export const ENGLISH_LANGUAGE_IDS = ["en", "en-us"] as const;
 export const API_MAX_CONCURRENT = 5;
 export const API_MIN_TIME_MS = 200;
 
-// Max articles to fetch per chunk (keeps each Inngest step under timeout)
-export const ELEVIO_CHUNK_SIZE = 10;
+// Max articles to fetch per chunk (keeps each Inngest step under timeout).
+// Each chunk runs fetchData + convertToMavenDocuments + Maven uploads in a
+// single step.run(), so this must be small enough that the combined work
+// (detail fetches + HTML→MD conversion + uploads) finishes well under 100s.
+export const ELEVIO_CHUNK_SIZE = 5;
+
+// Abort fetch requests that hang longer than this (ms)
+export const FETCH_TIMEOUT_MS = 30_000;


### PR DESCRIPTION
## Summary
- **Reduces `ELEVIO_CHUNK_SIZE` from 10 to 5** to limit work per Inngest `step.run()` well under the ~100s Cloudflare timeout
- **Parallelizes HTML→Markdown conversion** in `convertToMavenDocuments` using `Promise.all` instead of a sequential `for...of` loop — the primary bottleneck for large articles with complex HTML bodies
- **Adds 30s `AbortSignal.timeout`** to all Elevio API fetch calls to prevent individual requests from hanging and consuming the entire step budget

## Context
After merging the initial chunking fix (PR #8), 524 timeouts persisted. Inngest traces showed the execution step failing at ~2m 13s. Root cause: even with 10-article batches, the sequential `convert()` calls inside `convertToMavenDocuments` could take 5-30s per article for large TripAdvisor HTML bodies, blowing the timeout.

## Test plan
- [x] All 34 unit tests pass (chunking test updated for new chunk size: 12 articles → 5+5+2 across three chunks)
- [x] `pnpm build` succeeds
- [ ] Deploy and verify no 524 errors in Inngest execution traces
- [ ] Optionally validate timing with local Inngest dev server (`docker compose -f e2e/docker-compose.e2e.yml up`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)