### PR TITLE
fix(elevio): add maxDuration to Inngest route to prevent 524 timeouts

### DIFF
--- a/src/app/api/inngest/route.ts
+++ b/src/app/api/inngest/route.ts
@@ -1,1 +1,7 @@
 export { GET, POST, PUT } from "@mavenagi/apps-core/knowledge/inngest";
+
+// Extend Vercel serverless function timeout from the default (60s) to 300s.
+// Each Inngest step.run() invocation is a separate HTTP request — without this,
+// steps that include Redis cache operations + Maven API uploads can exceed
+// the default timeout and produce 524 errors from Cloudflare.
+export const maxDuration = 300;

--- a/src/knowledge-hooks.ts
+++ b/src/knowledge-hooks.ts
@@ -178,9 +178,7 @@ export async function convertToMavenDocuments(
   const articles = fetchResult as unknown as ElevioArticleDetail[];
   const { settings } = eventData;
 
-  // Filter to English translations first, then convert HTML→Markdown concurrently.
-  // Sequential conversion was a 524-timeout bottleneck — large HTML bodies
-  // can take several seconds each through the knowledge-converter.
+  // Filter to English translations, then convert HTML→Markdown concurrently.
   const articlesWithEnglish = articles
     .map((article) => {
       const englishTranslation = article.translations.find((t) =>
@@ -194,7 +192,7 @@ export async function convertToMavenDocuments(
       (item): item is NonNullable<typeof item> => item !== null,
     );
 
-  // Convert HTML→Markdown concurrently for all English articles
+  // Convert HTML→Markdown for all English articles concurrently
   const documents: MavenAGI.KnowledgeDocumentRequest[] = await Promise.all(
     articlesWithEnglish.map(async ({ article, englishTranslation }) => {
       const [_extractedTitle, markdownContent] = await convert({


### PR DESCRIPTION
## Summary

- Adds `maxDuration = 300` to the Inngest API route (`src/app/api/inngest/route.ts`), extending Vercel's serverless function timeout from the default 60s to 300s
- Without this, each `step.run()` invocation (which is a separate HTTP request) can exceed the 60s default when it includes Redis cache operations + Maven API `createKnowledgeDocument` uploads, resulting in 524 errors from Cloudflare
- Cleans up inaccurate comments in `knowledge-hooks.ts` (conversion was never the bottleneck — measured at <1ms total)

## Root cause analysis

Each apps-core `process-chunk-N` step executes: Redis cache.get → fetchData → convertToMavenDocuments → Maven API uploads (with eld language detection + createKnowledgeDocument per doc) → Redis cache.set — all within a single HTTP request/response. Timing diagnostics showed our hooks complete in ~1.2s per chunk, but the combined overhead of Redis gzip operations and Maven API calls inside apps-core exceeded the default Vercel timeout.

Reference: `private-quest-knowledge` uses `maxDuration = 800` on its Inngest route for the same reason.

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` — all 34 tests pass, no type errors
- [ ] Deploy and verify no more 524 errors on knowledge sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)