### PR TITLE
fix(elevio): remove slug from article URLs to match help center pattern

### DIFF
--- a/src/inngest/functions/process.test.ts
+++ b/src/inngest/functions/process.test.ts
@@ -174,7 +174,7 @@ describe("Elevio Knowledge Processor", () => {
           title: "Getting Started",
           contentType: "MARKDOWN",
           language: "en",
-          url: "https://help.example.com/traveler/articles/101-getting-started",
+          url: "https://help.example.com/traveler/articles/101",
           knowledgeDocumentId: { referenceId: "101" },
         }),
       );

--- a/src/inngest/functions/process.ts
+++ b/src/inngest/functions/process.ts
@@ -152,11 +152,10 @@ export const processFunction = inngest.createFunction(
                 return { id: article.id, status: "skipped" as const };
               }
 
-              // 4. Build article URL (SOLN-63 fix preserved)
+              // 4. Build article URL
               const url = buildArticleUrl(
                 settings.helpCenterUrl,
                 article.id,
-                article.slug,
                 article.tags,
               );
 

--- a/src/lib/url.test.ts
+++ b/src/lib/url.test.ts
@@ -27,16 +27,15 @@ describe("extractSection", () => {
 });
 
 describe("buildArticleUrl", () => {
-  it("should construct full URL with section, id, and slug", () => {
+  it("should construct URL with section and id only", () => {
     expect(
       buildArticleUrl(
         "https://www.tripadvisorsupport.com/en-US/hc",
         377,
-        "reporting-inaccurate-business-information",
         ["ct_traveler"],
       ),
     ).toBe(
-      "https://www.tripadvisorsupport.com/en-US/hc/traveler/articles/377-reporting-inaccurate-business-information",
+      "https://www.tripadvisorsupport.com/en-US/hc/traveler/articles/377",
     );
   });
 
@@ -45,31 +44,30 @@ describe("buildArticleUrl", () => {
       buildArticleUrl(
         "https://www.tripadvisorsupport.com/en-US/hc",
         402,
-        "updating-my-business-details",
         ["ct_owner"],
       ),
     ).toBe(
-      "https://www.tripadvisorsupport.com/en-US/hc/owner/articles/402-updating-my-business-details",
+      "https://www.tripadvisorsupport.com/en-US/hc/owner/articles/402",
     );
   });
 
   it("should strip trailing slash from helpCenterUrl", () => {
     expect(
-      buildArticleUrl("https://help.example.com/", 456, "test-article", [
+      buildArticleUrl("https://help.example.com/", 456, [
         "ct_traveler",
       ]),
-    ).toBe("https://help.example.com/traveler/articles/456-test-article");
+    ).toBe("https://help.example.com/traveler/articles/456");
   });
 
   it("should return empty string when helpCenterUrl is undefined", () => {
     expect(
-      buildArticleUrl(undefined, 123, "test", ["ct_traveler"]),
+      buildArticleUrl(undefined, 123, ["ct_traveler"]),
     ).toBe("");
   });
 
   it("should return empty string when no section tag exists", () => {
     expect(
-      buildArticleUrl("https://help.example.com", 123, "test", [
+      buildArticleUrl("https://help.example.com", 123, [
         "some-other-tag",
       ]),
     ).toBe("");
@@ -77,7 +75,7 @@ describe("buildArticleUrl", () => {
 
   it("should return empty string when tags are empty", () => {
     expect(
-      buildArticleUrl("https://help.example.com", 123, "test", []),
+      buildArticleUrl("https://help.example.com", 123, []),
     ).toBe("");
   });
 });

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -16,9 +16,9 @@ export function extractSection(tags: string[]): string | undefined {
 /**
  * Construct the public URL for an Elevio help center article.
  *
- * Uses the article's tags to determine the section and the API-provided slug.
+ * Uses the article's tags to determine the section.
  *
- * Pattern: {helpCenterUrl}/{section}/articles/{id}-{slug}
+ * Pattern: {helpCenterUrl}/{section}/articles/{id}
  *
  * The `helpCenterUrl` setting should be the base path up to (but not including)
  * the section. For example: "https://www.tripadvisorsupport.com/en-US/hc"
@@ -28,7 +28,6 @@ export function extractSection(tags: string[]): string | undefined {
 export function buildArticleUrl(
   helpCenterUrl: string | undefined,
   articleId: number,
-  slug: string,
   tags: string[],
 ): string {
   if (!helpCenterUrl) {
@@ -41,5 +40,5 @@ export function buildArticleUrl(
   }
 
   const baseUrl = helpCenterUrl.replace(/\/$/, "");
-  return `${baseUrl}/${section}/articles/${articleId}-${slug}`;
+  return `${baseUrl}/${section}/articles/${articleId}`;
 }


### PR DESCRIPTION
## Summary
- Article URLs were being generated as `{helpCenterUrl}/{section}/articles/{id}-{slug}` but the actual help center uses `{helpCenterUrl}/{section}/articles/{id}` (no slug).
- Removed the `slug` parameter from `buildArticleUrl()` so generated URLs match the real help center pattern.
- Example: `https://www.tripadvisorsupport.com/en-US/hc/owner/articles/637` instead of `https://www.tripadvisorsupport.com/en-US/hc/owner/articles/637-manage-your-business-listing-before-during-and-after-a-severe-event`

## Test plan
- [x] All 32 tests pass (`pnpm test`)
- [x] No type errors
- [x] Verified generated URLs match actual help center URLs via curl (200 responses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)